### PR TITLE
Equipment change to Equipments and remove accessories.

### DIFF
--- a/db/migrate/20170220150733_create_equipment.rb
+++ b/db/migrate/20170220150733_create_equipment.rb
@@ -1,12 +1,11 @@
 class CreateEquipment < ActiveRecord::Migration[5.0]
   def change
-    create_table :equipment do |t|
+    create_table :equipments do |t|
       t.string :category
       t.string :brand
       t.string :model
       t.integer :price
       t.text :description
-      t.text :accessories
       t.string :location
       t.references :user, foreign_key: true
 


### PR DESCRIPTION
Roll back migration twice and then run 'rails db:migrate'

Equipment (singular) is model name so to respect proper convention we need to pluralize table name to Equipments for controller